### PR TITLE
fix: 调整测试中的路径导入

### DIFF
--- a/archive/tests/test_config_syntax.py
+++ b/archive/tests/test_config_syntax.py
@@ -10,8 +10,10 @@ import os
 def test_config_syntax():
     """测试配置文件语法"""
     try:
-        # 尝试导入配置文件
-        sys.path.insert(0, os.path.abspath('.'))
+        # 根据当前文件位置计算项目根目录并加入 Python 路径
+        project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+        if project_root not in sys.path:
+            sys.path.insert(0, project_root)
         import scripts.config
         
         print("✅ 配置文件语法正确！")

--- a/archive/tests/test_post_process_validator.py
+++ b/archive/tests/test_post_process_validator.py
@@ -8,8 +8,10 @@ import sys
 import os
 import logging
 
-# 添加项目根目录到Python路径
-sys.path.insert(0, os.path.abspath('.'))
+# 根据当前文件位置计算项目根目录并加入 Python 路径
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
 
 from scripts.utils.post_process_validator import (
     PostProcessValidator, 

--- a/archive/tests/test_punctuation_integration.py
+++ b/archive/tests/test_punctuation_integration.py
@@ -9,8 +9,10 @@
 import sys
 import os
 
-# 添加项目根目录到Python路径
-sys.path.insert(0, os.path.abspath('.'))
+# 根据当前文件位置计算项目根目录并加入 Python 路径
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
 
 def test_punctuation_handler():
     """测试标点符号处理工具模块"""

--- a/archive/tests/test_punctuation_system.py
+++ b/archive/tests/test_punctuation_system.py
@@ -9,8 +9,10 @@
 import sys
 import os
 
-# 添加项目根目录到Python路径
-sys.path.insert(0, os.path.abspath('.'))
+# 根据当前文件位置计算项目根目录并加入 Python 路径
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
 
 def test_basic_functionality():
     """测试基本功能"""

--- a/archive/tests/test_simple_validator.py
+++ b/archive/tests/test_simple_validator.py
@@ -8,8 +8,10 @@ import sys
 import os
 import logging
 
-# 添加项目根目录到Python路径
-sys.path.insert(0, os.path.abspath('.'))
+# 根据当前文件位置计算项目根目录并加入 Python 路径
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
 
 # 设置日志
 logging.basicConfig(

--- a/archive/tests/test_version_display.py
+++ b/archive/tests/test_version_display.py
@@ -7,8 +7,8 @@
 import os
 import sys
 
-# 添加项目根目录到Python路径
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '.'))
+# 根据当前文件位置计算项目根目录并加入 Python 路径
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 

--- a/archive/tests/test_vic3_simple.py
+++ b/archive/tests/test_vic3_simple.py
@@ -7,8 +7,10 @@ Victoria 3 验证器简单测试脚本
 import sys
 import os
 
-# 添加项目根目录到Python路径
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# 根据当前文件位置计算项目根目录并加入 Python 路径
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
 
 # 设置环境变量跳过语言选择
 os.environ['SKIP_LANGUAGE_SELECTION'] = '1'


### PR DESCRIPTION
## Summary
- 统一测试文件中的项目根目录计算方式，避免重复插入无效路径
- 保留中文注释，说明路径设置逻辑

## Testing
- `PYTHONPATH=$(pwd) pytest` *(部分测试因缺失 utils 模块及语法错误导致导入失败)*

------
https://chatgpt.com/codex/tasks/task_e_68c4331da94c83298a9f86fa45ffdf69