### PR TITLE
实现安全重载机制

### DIFF
--- a/scripts/utils/state_manager.py
+++ b/scripts/utils/state_manager.py
@@ -1,6 +1,11 @@
 """简单的状态管理器，用于跨回调传递重启命令"""
+
+import time
+
+
 class StateManager:
     """维护需要执行的命令"""
+
     def __init__(self):
         self.command = None
 
@@ -8,6 +13,21 @@ class StateManager:
         self.command = cmd
 
     def get_command(self):
+        return self.command
+
+    def wait_for_command(self, timeout: float = 5.0):
+        """阻塞等待命令直到超时
+
+        Args:
+            timeout: 超时时间（秒）
+        Returns:
+            获取到的命令字符串，若在超时时间内未收到命令则返回 None
+        """
+        start = time.time()
+        while self.command is None:
+            if timeout is not None and time.time() - start > timeout:
+                return None
+            time.sleep(0.1)
         return self.command
 
     def clear(self):


### PR DESCRIPTION
## Summary
- 增加 `wait_for_command` 方法实现阻塞式命令监听
- 回调函数仅发送重启指令，实际关闭交由主循环处理
- 主循环改为哨兵模式，统一管理重启与退出

## Testing
- `pytest` *(失败：ModuleNotFoundError: No module named 'scripts')*

------
https://chatgpt.com/codex/tasks/task_e_68c7f3f267b48329ba53e3f6cb0ababc