### PR TITLE
fix(core): Update Gemini API client initialization

### DIFF
--- a/scripts/core/gemini_handler.py
+++ b/scripts/core/gemini_handler.py
@@ -17,8 +17,9 @@ class GeminiHandler(BaseApiHandler):
             self.logger.error("API Key 'GEMINI_API_KEY' not found in environment variables.")
             raise ValueError("GEMINI_API_KEY not set")
         try:
-            genai.configure(api_key=api_key)
-            client = genai.Client()
+            # The genai.configure() method is deprecated.
+            # The API key is now passed directly to the genai.Client constructor.
+            client = genai.Client(api_key=api_key)
             self.logger.info("Gemini client initialized successfully.")
             return client
         except Exception as e:


### PR DESCRIPTION
The `google-generativeai` library has deprecated the `genai.configure()` method for API key setup. This change was causing an `AttributeError` at startup.

This commit updates the client initialization in `scripts/core/gemini_handler.py` to pass the API key directly to the `genai.Client()` constructor, as per the latest library documentation. This resolves the startup crash.