### PR TITLE
Persist agent workshop fix failures

### DIFF
--- a/scripts/routers/agent_workshop.py
+++ b/scripts/routers/agent_workshop.py
@@ -60,10 +60,15 @@ class ValidationIssue(BaseModel):
     target_lang: Optional[str] = None
     generated_at: Optional[str] = None
     status: Optional[str] = "detected" # New: status tracking
+    failure_reason: Optional[str] = None
+    failure_details: Optional[str] = None
+    last_suggested_fix: Optional[str] = None
+    last_attempt_at: Optional[str] = None
 
 class FixRequest(BaseModel):
     project_id: str
     file_name: str
+    file_path: Optional[str] = None
     key: str
     source_str: str
     target_str: str
@@ -117,6 +122,10 @@ def _normalize_issue_dict(issue: Dict[str, Any]) -> Dict[str, Any]:
     normalized.setdefault("target_lang", None)
     normalized.setdefault("generated_at", None)
     normalized.setdefault("status", "detected")
+    normalized.setdefault("failure_reason", None)
+    normalized.setdefault("failure_details", None)
+    normalized.setdefault("last_suggested_fix", None)
+    normalized.setdefault("last_attempt_at", None)
     return normalized
 
 
@@ -364,8 +373,12 @@ async def load_cached_errors(project_id: str):
 
     sidecar_issues = _load_project_sidecar_issues(project)
     if sidecar_issues:
-        ValidationLogger.save_errors(project['source_path'], [issue.model_dump() for issue in sidecar_issues])
-        return sidecar_issues
+        active_issues = [
+            issue for issue in sidecar_issues
+            if str(issue.status or "detected").lower() not in {"fixed", "ignored"}
+        ]
+        ValidationLogger.save_errors(project['source_path'], [issue.model_dump() for issue in active_issues])
+        return active_issues
 
     return []
 
@@ -399,8 +412,12 @@ async def scan_project(project_id: str, force: bool = Query(False)):
                 len(sidecar_issues),
                 project_id,
             )
-            ValidationLogger.save_errors(project['source_path'], [issue.model_dump() for issue in sidecar_issues])
-            return sidecar_issues
+            active_issues = [
+                issue for issue in sidecar_issues
+                if str(issue.status or "detected").lower() not in {"fixed", "ignored"}
+            ]
+            ValidationLogger.save_errors(project['source_path'], [issue.model_dump() for issue in active_issues])
+            return active_issues
 
     logger.info(
         "[AgentWorkshop] Fresh scan started for project %s (%s) at %s",
@@ -530,6 +547,97 @@ def apply_translation_fix_to_file(file_path: Path, key_to_fix: str, new_value: s
         return False
 
 
+def _infer_target_lang_from_issue(issue_file_name: Optional[str], explicit_target_lang: Optional[str] = None) -> Optional[str]:
+    if explicit_target_lang:
+        return explicit_target_lang
+    if not issue_file_name:
+        return None
+
+    from scripts.utils.i18n_utils import paradox_to_iso
+
+    match = re.search(r"_l_([a-z_]+)\.yml$", issue_file_name, re.IGNORECASE)
+    if not match:
+        return None
+    return paradox_to_iso(match.group(1))
+
+
+def _read_translation_value(file_path: Path, key_to_find: str) -> Optional[str]:
+    try:
+        entries = dict(parse_loc_file(file_path))
+    except Exception as exc:
+        logger.error(f"Failed to parse updated translation file {file_path}: {exc}")
+        return None
+
+    if key_to_find in entries:
+        return entries[key_to_find]
+
+    base_key = key_to_find.split(":")[0]
+    if base_key in entries:
+        return entries[base_key]
+
+    normalized_key = f"{base_key}:0"
+    return entries.get(normalized_key)
+
+
+def _post_validate_fixed_translation(
+    game_id: str,
+    key: str,
+    source_str: str,
+    target_str: str,
+    target_lang: Optional[str] = None,
+) -> List[str]:
+    validator = PostProcessValidator()
+    try:
+        results = validator.validate_entry(
+            game_id=game_id,
+            key=key,
+            value=target_str,
+            source_value=source_str,
+            target_lang=target_lang,
+        )
+    except Exception as exc:
+        return [f"Post-validation crashed: {exc}"]
+
+    return [result.message for result in results if result.level.value == "error"]
+
+
+def _apply_fix_with_confirmation(
+    project: Dict[str, Any],
+    game_id: str,
+    file_name: str,
+    file_path: Optional[str],
+    key: str,
+    source_str: str,
+    suggested_fix: str,
+    target_lang: Optional[str] = None,
+) -> tuple[bool, str, str]:
+    target_path = _resolve_issue_target_path(project, file_path, file_name)
+    if not target_path or not target_path.exists():
+        return False, "target_not_found", "Target file not found for fix application."
+
+    if not apply_translation_fix_to_file(target_path, key, suggested_fix):
+        return False, "writeback_failure", "Failed to write suggested fix to target file."
+
+    current_value = _read_translation_value(target_path, key)
+    if current_value is None:
+        return False, "readback_missing", "Fixed entry could not be read back from target file."
+
+    if current_value != suggested_fix:
+        return False, "readback_mismatch", "Read-back confirmation mismatch after writing fix."
+
+    validation_errors = _post_validate_fixed_translation(
+        game_id=game_id,
+        key=key,
+        source_str=source_str,
+        target_str=current_value,
+        target_lang=target_lang,
+    )
+    if validation_errors:
+        return False, "post_validation_failure", "Post-write validation failed: " + " | ".join(validation_errors)
+
+    return True, "validated_and_applied", "Applied and re-validated successfully."
+
+
 @router.post("/fix", response_model=FixResult)
 async def fix_issue(request: FixRequest):
     """
@@ -568,27 +676,50 @@ async def fix_issue(request: FixRequest):
     result["report_path"] = None
 
     if result.get('status') == 'SUCCESS' and project:
-        target_path = _resolve_issue_target_path(project, request.file_path, request.file_name)
-        if target_path and target_path.exists():
-            apply_translation_fix_to_file(target_path, request.key, result['suggested_fix'])
-            
-        ValidationLogger.update_error_status(
-            project['source_path'], 
-            request.file_name, 
-            request.key, 
-            "fixed"
+        target_lang = _infer_target_lang_from_issue(request.file_name)
+        applied, failure_reason, apply_message = _apply_fix_with_confirmation(
+            project=project,
+            game_id=game_id,
+            file_name=request.file_name,
+            file_path=request.file_path,
+            key=request.key,
+            source_str=request.source_str,
+            suggested_fix=result.get("suggested_fix", ""),
+            target_lang=target_lang,
         )
-        result["report_path"] = _write_fix_report(
-            project['source_path'],
-            request.file_name,
-            request.key,
-            request.source_str,
-            request.target_str,
-            request.error_type,
-            request.details,
-            result.get("suggested_fix", ""),
-            concise_reflection,
-        )
+
+        if applied:
+            ValidationLogger.mark_attempt_result(
+                project['source_path'],
+                request.file_name,
+                request.key,
+                status="fixed",
+                last_suggested_fix=result.get("suggested_fix", ""),
+            )
+            result["report_path"] = _write_fix_report(
+                project['source_path'],
+                request.file_name,
+                request.key,
+                request.source_str,
+                request.target_str,
+                request.error_type,
+                request.details,
+                result.get("suggested_fix", ""),
+                concise_reflection,
+            )
+            result["parity_message"] = apply_message
+        else:
+            ValidationLogger.mark_attempt_result(
+                project['source_path'],
+                request.file_name,
+                request.key,
+                status="failed",
+                failure_reason=failure_reason,
+                failure_details=apply_message,
+                last_suggested_fix=result.get("suggested_fix", ""),
+            )
+            result["status"] = "FAILED"
+            result["parity_message"] = apply_message
     
     return FixResult(**result)
 
@@ -628,20 +759,6 @@ async def fix_batch(request: FixBatchRequest):
                     ),
                     None
                 )
-                target_path = _resolve_issue_target_path(
-                    project,
-                    original_issue.get("file_path") if original_issue else None,
-                    res["file_name"]
-                )
-                if target_path and target_path.exists():
-                    apply_translation_fix_to_file(target_path, res["key"], res["suggested_fix"])
-                    
-                ValidationLogger.update_error_status(
-                    project['source_path'], 
-                    res["file_name"], 
-                    res["key"], 
-                    "fixed"
-                )
                 concise_reflection = _build_concise_reflection(
                     original_issue.get("error_type") if original_issue else "",
                     original_issue.get("details") if original_issue else "",
@@ -649,17 +766,53 @@ async def fix_batch(request: FixBatchRequest):
                     original_issue.get("target_str") if original_issue else "",
                     res.get("suggested_fix", ""),
                 )
-                res["report_path"] = _write_fix_report(
-                    project['source_path'],
+                target_lang = _infer_target_lang_from_issue(
                     res["file_name"],
-                    res["key"],
-                    original_issue.get("source_str") if original_issue else "",
-                    original_issue.get("target_str") if original_issue else "",
-                    original_issue.get("error_type") if original_issue else "",
-                    original_issue.get("details") if original_issue else "",
-                    res.get("suggested_fix", ""),
-                    concise_reflection,
+                    original_issue.get("target_lang") if original_issue else None,
                 )
+                applied, failure_reason, apply_message = _apply_fix_with_confirmation(
+                    project=project,
+                    game_id=game_id,
+                    file_name=res["file_name"],
+                    file_path=original_issue.get("file_path") if original_issue else None,
+                    key=res["key"],
+                    source_str=original_issue.get("source_str") if original_issue else "",
+                    suggested_fix=res.get("suggested_fix", ""),
+                    target_lang=target_lang,
+                )
+                if applied:
+                    ValidationLogger.mark_attempt_result(
+                        project['source_path'],
+                        res["file_name"],
+                        res["key"],
+                        status="fixed",
+                        last_suggested_fix=res.get("suggested_fix", ""),
+                    )
+                    res["report_path"] = _write_fix_report(
+                        project['source_path'],
+                        res["file_name"],
+                        res["key"],
+                        original_issue.get("source_str") if original_issue else "",
+                        original_issue.get("target_str") if original_issue else "",
+                        original_issue.get("error_type") if original_issue else "",
+                        original_issue.get("details") if original_issue else "",
+                        res.get("suggested_fix", ""),
+                        concise_reflection,
+                    )
+                    res["parity_message"] = apply_message
+                else:
+                    ValidationLogger.mark_attempt_result(
+                        project['source_path'],
+                        res["file_name"],
+                        res["key"],
+                        status="failed",
+                        failure_reason=failure_reason,
+                        failure_details=apply_message,
+                        last_suggested_fix=res.get("suggested_fix", ""),
+                    )
+                    res["status"] = "FAILED"
+                    res["parity_message"] = apply_message
+                    res["report_path"] = None
             else:
                 res["report_path"] = None
             final_results.append(BatchResultItem(**res))

--- a/scripts/utils/validation_logger.py
+++ b/scripts/utils/validation_logger.py
@@ -2,6 +2,7 @@ import json
 import os
 from pathlib import Path
 from typing import List, Dict, Any, Optional
+from datetime import datetime
 
 class ValidationLogger:
     """
@@ -56,6 +57,51 @@ class ValidationLogger:
         
         if updated:
             ValidationLogger.save_errors(project_root, errors)
+
+    @staticmethod
+    def update_error_metadata(project_root: str, file_name: str, key: str, updates: Dict[str, Any]):
+        """
+        Updates arbitrary metadata for a specific error entry.
+        """
+        errors = ValidationLogger.load_errors(project_root)
+        updated = False
+        for err in errors:
+            if err.get('file_name') == file_name and err.get('key') == key:
+                err.update(updates)
+                updated = True
+
+        if updated:
+            ValidationLogger.save_errors(project_root, errors)
+
+    @staticmethod
+    def mark_attempt_result(
+        project_root: str,
+        file_name: str,
+        key: str,
+        *,
+        status: str,
+        failure_reason: Optional[str] = None,
+        failure_details: Optional[str] = None,
+        last_suggested_fix: Optional[str] = None,
+    ):
+        """
+        Records the latest attempt outcome for a specific issue.
+        """
+        payload: Dict[str, Any] = {
+            "status": status,
+            "last_attempt_at": datetime.now().isoformat(timespec="seconds"),
+        }
+        if last_suggested_fix is not None:
+            payload["last_suggested_fix"] = last_suggested_fix
+
+        if status == "failed":
+            payload["failure_reason"] = failure_reason or "unknown_failure"
+            payload["failure_details"] = failure_details or ""
+        else:
+            payload["failure_reason"] = None
+            payload["failure_details"] = None
+
+        ValidationLogger.update_error_metadata(project_root, file_name, key, payload)
 
     @staticmethod
     def clear_fixes(project_root: str):

--- a/tests/test_routers_agent_workshop.py
+++ b/tests/test_routers_agent_workshop.py
@@ -1,0 +1,479 @@
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from scripts.core.project_json_manager import ProjectJsonManager
+from scripts.routers.agent_workshop import apply_translation_fix_to_file
+from scripts.utils.validation_logger import ValidationLogger
+from scripts.web_server import app
+
+
+client = TestClient(app)
+
+
+def _write_loc_file(path: Path, header: str, entries: list[tuple[str, str]]):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"{header}:\n"]
+    for key, value in entries:
+        lines.append(f' {key} "{value}"\n')
+    path.write_text("".join(lines), encoding="utf-8-sig")
+
+
+def test_load_cached_filters_fixed_entries(tmp_path):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    ValidationLogger.save_errors(str(project_root), [
+        {
+            "file_name": "a.yml",
+            "key": "demo.one",
+            "source_str": "src",
+            "target_str": "dst",
+            "error_type": "validation_error",
+            "details": "broken",
+            "status": "detected",
+        },
+        {
+            "file_name": "b.yml",
+            "key": "demo.two",
+            "source_str": "src",
+            "target_str": "dst",
+            "error_type": "validation_error",
+            "details": "broken",
+            "status": "fixed",
+        },
+    ])
+
+    with patch("scripts.routers.agent_workshop.project_manager", new_callable=MagicMock) as mock_pm:
+        mock_pm.get_project = AsyncMock(return_value={
+            "project_id": "p1",
+            "source_path": str(project_root),
+            "game_id": "victoria3",
+        })
+
+        response = client.get("/api/agent-workshop/load-cached", params={"project_id": "p1"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["file_name"] == "a.yml"
+    assert data[0]["status"] == "detected"
+
+
+def test_load_cached_falls_back_to_workshop_sidecar(tmp_path):
+    project_root = tmp_path / "project"
+    translation_root = tmp_path / "translation"
+    project_root.mkdir()
+    translation_root.mkdir()
+
+    ProjectJsonManager(str(project_root)).update_config({
+        "translation_dirs": [str(translation_root)]
+    })
+    (translation_root / "workshop_issues.json").write_text(
+        json.dumps({
+            "generated_at": "2026-04-03T10:00:00",
+            "issue_count": 2,
+            "issues": [
+                {
+                    "file_name": "events/test_l_simp_chinese.yml",
+                    "key": "demo.one",
+                    "source_str": "Hello",
+                    "target_str": "坏译文",
+                    "error_type": "validation_error",
+                    "error_code": "validation_error",
+                    "details": "broken",
+                    "status": "detected",
+                },
+                {
+                    "file_name": "events/test_l_simp_chinese.yml",
+                    "key": "demo.two",
+                    "source_str": "World",
+                    "target_str": "旧译文",
+                    "error_type": "validation_error",
+                    "error_code": "validation_error",
+                    "details": "broken",
+                    "status": "fixed",
+                },
+            ],
+        }),
+        encoding="utf-8",
+    )
+
+    with patch("scripts.routers.agent_workshop.project_manager", new_callable=MagicMock) as mock_pm:
+        mock_pm.get_project = AsyncMock(return_value={
+            "project_id": "p2",
+            "source_path": str(project_root),
+            "game_id": "victoria3",
+        })
+
+        response = client.get("/api/agent-workshop/load-cached", params={"project_id": "p2"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["key"] == "demo.one"
+
+    cached = ValidationLogger.load_errors(str(project_root))
+    assert len(cached) == 1
+    assert cached[0]["key"] == "demo.one"
+
+
+def test_fix_issue_updates_file_status_and_report(tmp_path):
+    project_root = tmp_path / "project"
+    translation_root = tmp_path / "translation"
+    translation_file = translation_root / "events" / "test_l_simp_chinese.yml"
+    project_root.mkdir()
+    ProjectJsonManager(str(project_root)).update_config({
+        "translation_dirs": [str(translation_root)]
+    })
+    _write_loc_file(
+        translation_file,
+        "l_simp_chinese",
+        [("demo.one:0", "坏译文"), ("demo.two:0", "其他内容")],
+    )
+    ValidationLogger.save_errors(str(project_root), [{
+        "file_name": "events/test_l_simp_chinese.yml",
+        "key": "demo.one:0",
+        "source_str": "Hello",
+        "target_str": "坏译文",
+        "error_type": "validation_error",
+        "details": "broken",
+        "status": "detected",
+    }])
+
+    mock_agent = MagicMock()
+    mock_agent.fix_issue_loop = AsyncMock(return_value={
+        "suggested_fix": "修复译文",
+        "reflection": "placeholder",
+        "status": "SUCCESS",
+        "parity_message": "Validation passed",
+    })
+
+    with patch("scripts.routers.agent_workshop.project_manager", new_callable=MagicMock) as mock_pm, \
+         patch("scripts.routers.agent_workshop.ReflexionFixAgent", return_value=mock_agent), \
+         patch("scripts.core.api_handler.get_handler", return_value=MagicMock()):
+        mock_pm.get_project = AsyncMock(return_value={
+            "project_id": "p3",
+            "source_path": str(project_root),
+            "game_id": "victoria3",
+        })
+
+        response = client.post("/api/agent-workshop/fix", json={
+            "project_id": "p3",
+            "file_name": "events/test_l_simp_chinese.yml",
+            "file_path": str(translation_file),
+            "key": "demo.one:0",
+            "source_str": "Hello",
+            "target_str": "坏译文",
+            "error_type": "validation_error",
+            "details": "broken",
+            "api_provider": "gemini",
+            "api_model": "gemini-3-flash-preview",
+        })
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "SUCCESS"
+    assert payload["suggested_fix"] == "修复译文"
+    assert payload["report_path"]
+    assert Path(payload["report_path"]).exists()
+
+    content = translation_file.read_text(encoding="utf-8-sig")
+    assert 'demo.one:0 "修复译文"' in content
+
+    cached = ValidationLogger.load_errors(str(project_root))
+    assert cached[0]["status"] == "fixed"
+
+
+def test_fix_issue_does_not_mark_fixed_when_apply_fails(tmp_path):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    ValidationLogger.save_errors(str(project_root), [{
+        "file_name": "events/test_l_simp_chinese.yml",
+        "key": "demo.one:0",
+        "source_str": "Hello",
+        "target_str": "坏译文",
+        "error_type": "validation_error",
+        "details": "broken",
+        "status": "detected",
+    }])
+
+    mock_agent = MagicMock()
+    mock_agent.fix_issue_loop = AsyncMock(return_value={
+        "suggested_fix": "修复译文",
+        "reflection": "placeholder",
+        "status": "SUCCESS",
+        "parity_message": "Validation passed",
+    })
+
+    with patch("scripts.routers.agent_workshop.project_manager", new_callable=MagicMock) as mock_pm, \
+         patch("scripts.routers.agent_workshop.ReflexionFixAgent", return_value=mock_agent), \
+         patch("scripts.core.api_handler.get_handler", return_value=MagicMock()):
+        mock_pm.get_project = AsyncMock(return_value={
+            "project_id": "p5",
+            "source_path": str(project_root),
+            "game_id": "victoria3",
+        })
+
+        response = client.post("/api/agent-workshop/fix", json={
+            "project_id": "p5",
+            "file_name": "events/test_l_simp_chinese.yml",
+            "key": "demo.one:0",
+            "source_str": "Hello",
+            "target_str": "坏译文",
+            "error_type": "validation_error",
+            "details": "broken",
+            "api_provider": "gemini",
+            "api_model": "gemini-3-flash-preview",
+        })
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "FAILED"
+    assert "Target file not found" in payload["parity_message"]
+    assert payload["report_path"] is None
+
+    cached = ValidationLogger.load_errors(str(project_root))
+    assert cached[0]["status"] == "failed"
+    assert cached[0]["failure_reason"] == "target_not_found"
+    assert "Target file not found" in cached[0]["failure_details"]
+    assert cached[0]["last_suggested_fix"] == payload["suggested_fix"]
+    assert cached[0]["last_attempt_at"]
+
+
+def test_fix_batch_only_marks_successful_items_fixed(tmp_path):
+    project_root = tmp_path / "project"
+    translation_root = tmp_path / "translation"
+    translation_file = translation_root / "events" / "test_l_simp_chinese.yml"
+    project_root.mkdir()
+    ProjectJsonManager(str(project_root)).update_config({
+        "translation_dirs": [str(translation_root)]
+    })
+    _write_loc_file(
+        translation_file,
+        "l_simp_chinese",
+        [("demo.one:0", "坏译文一"), ("demo.two:0", "坏译文二")],
+    )
+    ValidationLogger.save_errors(str(project_root), [
+        {
+            "file_name": "events/test_l_simp_chinese.yml",
+            "key": "demo.one:0",
+            "source_str": "Hello",
+            "target_str": "坏译文一",
+            "error_type": "validation_error",
+            "details": "broken",
+            "status": "detected",
+        },
+        {
+            "file_name": "events/test_l_simp_chinese.yml",
+            "key": "demo.two:0",
+            "source_str": "World",
+            "target_str": "坏译文二",
+            "error_type": "validation_error",
+            "details": "broken",
+            "status": "detected",
+        },
+    ])
+
+    mock_agent = MagicMock()
+    mock_agent.fix_batch_loop = AsyncMock(return_value={
+        "results": [
+            {
+                "file_name": "events/test_l_simp_chinese.yml",
+                "key": "demo.one:0",
+                "suggested_fix": "修复一",
+                "status": "SUCCESS",
+                "parity_message": "Validation passed",
+            },
+            {
+                "file_name": "events/test_l_simp_chinese.yml",
+                "key": "demo.two:0",
+                "suggested_fix": "失败建议",
+                "status": "FAILED",
+                "parity_message": "Still broken",
+            },
+        ]
+    })
+
+    with patch("scripts.routers.agent_workshop.project_manager", new_callable=MagicMock) as mock_pm, \
+         patch("scripts.routers.agent_workshop.ReflexionFixAgent", return_value=mock_agent), \
+         patch("scripts.core.api_handler.get_handler", return_value=MagicMock()):
+        mock_pm.get_project = AsyncMock(return_value={
+            "project_id": "p4",
+            "source_path": str(project_root),
+            "game_id": "victoria3",
+        })
+
+        response = client.post("/api/agent-workshop/fix-batch", json={
+            "project_id": "p4",
+            "api_provider": "gemini",
+            "api_model": "gemini-3-flash-preview",
+            "issues": [
+                {
+                    "file_name": "events/test_l_simp_chinese.yml",
+                    "file_path": str(translation_file),
+                    "key": "demo.one:0",
+                    "source_str": "Hello",
+                    "target_str": "坏译文一",
+                    "error_type": "validation_error",
+                    "details": "broken",
+                },
+                {
+                    "file_name": "events/test_l_simp_chinese.yml",
+                    "file_path": str(translation_file),
+                    "key": "demo.two:0",
+                    "source_str": "World",
+                    "target_str": "坏译文二",
+                    "error_type": "validation_error",
+                    "details": "broken",
+                },
+            ],
+        })
+
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert [item["status"] for item in results] == ["SUCCESS", "FAILED"]
+    assert results[0]["report_path"]
+    assert results[1]["report_path"] is None
+
+    content = translation_file.read_text(encoding="utf-8-sig")
+    assert 'demo.one:0 "修复一"' in content
+    assert 'demo.two:0 "坏译文二"' in content
+
+    status_map = {
+        item["key"]: item["status"]
+        for item in ValidationLogger.load_errors(str(project_root))
+    }
+    assert status_map["demo.one:0"] == "fixed"
+    assert status_map["demo.two:0"] == "detected"
+
+
+def test_fix_batch_does_not_mark_fixed_when_post_validation_fails(tmp_path):
+    project_root = tmp_path / "project"
+    translation_root = tmp_path / "translation"
+    translation_file = translation_root / "events" / "test_l_simp_chinese.yml"
+    project_root.mkdir()
+    ProjectJsonManager(str(project_root)).update_config({
+        "translation_dirs": [str(translation_root)]
+    })
+    _write_loc_file(
+        translation_file,
+        "l_simp_chinese",
+        [("demo.one:0", "坏译文一")],
+    )
+    ValidationLogger.save_errors(str(project_root), [{
+        "file_name": "events/test_l_simp_chinese.yml",
+        "key": "demo.one:0",
+        "source_str": "Hello",
+        "target_str": "坏译文一",
+        "error_type": "validation_error",
+        "details": "broken",
+        "status": "detected",
+        "target_lang": "zh-CN",
+    }])
+
+    mock_agent = MagicMock()
+    mock_agent.fix_batch_loop = AsyncMock(return_value={
+        "results": [
+            {
+                "file_name": "events/test_l_simp_chinese.yml",
+                "key": "demo.one:0",
+                "suggested_fix": "会写回但校验失败",
+                "status": "SUCCESS",
+                "parity_message": "Validation passed",
+            }
+        ]
+    })
+
+    fake_error = MagicMock()
+    fake_error.level.value = "error"
+    fake_error.message = "still_invalid"
+
+    with patch("scripts.routers.agent_workshop.project_manager", new_callable=MagicMock) as mock_pm, \
+         patch("scripts.routers.agent_workshop.ReflexionFixAgent", return_value=mock_agent), \
+         patch("scripts.core.api_handler.get_handler", return_value=MagicMock()), \
+         patch("scripts.routers.agent_workshop.PostProcessValidator") as mock_validator_cls:
+        mock_pm.get_project = AsyncMock(return_value={
+            "project_id": "p6",
+            "source_path": str(project_root),
+            "game_id": "victoria3",
+        })
+        mock_validator_cls.return_value.validate_entry.return_value = [fake_error]
+
+        response = client.post("/api/agent-workshop/fix-batch", json={
+            "project_id": "p6",
+            "api_provider": "gemini",
+            "api_model": "gemini-3-flash-preview",
+            "issues": [
+                {
+                    "file_name": "events/test_l_simp_chinese.yml",
+                    "file_path": str(translation_file),
+                    "key": "demo.one:0",
+                    "source_str": "Hello",
+                    "target_str": "坏译文一",
+                    "error_type": "validation_error",
+                    "details": "broken",
+                    "target_lang": "zh-CN",
+                }
+            ],
+        })
+
+    assert response.status_code == 200
+    result = response.json()["results"][0]
+    assert result["status"] == "FAILED"
+    assert "Post-write validation failed" in result["parity_message"]
+    assert result["report_path"] is None
+
+    cached = ValidationLogger.load_errors(str(project_root))
+    assert cached[0]["status"] == "failed"
+    assert cached[0]["failure_reason"] == "post_validation_failure"
+    assert "Post-write validation failed" in cached[0]["failure_details"]
+    assert cached[0]["last_suggested_fix"] == result["suggested_fix"]
+    assert cached[0]["last_attempt_at"]
+
+
+def test_apply_translation_fix_to_file_escapes_quotes(tmp_path):
+    target_file = tmp_path / "quoted_l_simp_chinese.yml"
+    _write_loc_file(
+        target_file,
+        "l_simp_chinese",
+        [("demo.one:0", "坏译文")],
+    )
+
+    updated = apply_translation_fix_to_file(target_file, "demo.one:0", '修复 "引号" 文本')
+
+    assert updated is True
+    content = target_file.read_text(encoding="utf-8-sig")
+    assert 'demo.one:0 "修复 \\"引号\\" 文本"' in content
+
+
+def test_apply_translation_fix_to_file_matches_base_key(tmp_path):
+    target_file = tmp_path / "basekey_l_simp_chinese.yml"
+    _write_loc_file(
+        target_file,
+        "l_simp_chinese",
+        [("demo.one:0", "旧文本"), ("demo.two:0", "保持不变")],
+    )
+
+    updated = apply_translation_fix_to_file(target_file, "demo.one", "基础键也能更新")
+
+    assert updated is True
+    content = target_file.read_text(encoding="utf-8-sig")
+    assert 'demo.one:0 "基础键也能更新"' in content
+    assert 'demo.two:0 "保持不变"' in content
+
+
+def test_apply_translation_fix_to_file_returns_false_when_missing_key(tmp_path):
+    target_file = tmp_path / "missing_l_simp_chinese.yml"
+    _write_loc_file(
+        target_file,
+        "l_simp_chinese",
+        [("demo.one:0", "旧文本")],
+    )
+    original_content = target_file.read_text(encoding="utf-8-sig")
+
+    updated = apply_translation_fix_to_file(target_file, "demo.unknown:0", "不会写入")
+
+    assert updated is False
+    assert target_file.read_text(encoding="utf-8-sig") == original_content


### PR DESCRIPTION
## Summary
- store structured failure metadata for agent workshop issues
- require writeback confirmation plus post-validation before marking fixes successful
- add regression tests for single-fix, batch-fix, and writeback edge cases

## Testing
- pytest tests/test_routers_agent_workshop.py tests/test_routers_projects.py tests/test_incremental_mvp_regression.py -q